### PR TITLE
Fix 無法傳送中文檔名的圖片

### DIFF
--- a/chat/kit/src/main/java/cn/wildfire/chat/kit/viewmodel/MessageViewModel.java
+++ b/chat/kit/src/main/java/cn/wildfire/chat/kit/viewmodel/MessageViewModel.java
@@ -225,8 +225,12 @@ public class MessageViewModel extends ViewModel implements OnReceiveMessageListe
     }
 
     public void sendImgMsg(Conversation conversation, File imageFileThumb, File imageFileSource) {
-        Uri imageFileThumbUri = Uri.fromFile(imageFileThumb);
-        Uri imageFileSourceUri = Uri.fromFile(imageFileSource);
+        // Uri.fromFile()遇到中文檔名會轉 ASCII，這個 ASCII 的 path 將導致後面 ChatManager.sendMessage()
+        // 在 new File()時找不到 File 而 return
+        Uri imageFileThumbUri = Uri.parse(Uri.decode(imageFileThumb.getAbsolutePath()));
+//        Uri imageFileThumbUri = Uri.fromFile(imageFileThumb);
+        Uri imageFileSourceUri = Uri.parse(Uri.decode(imageFileSource.getAbsolutePath()));
+//        Uri imageFileSourceUri = Uri.fromFile(imageFileSource);
         sendImgMsg(conversation, imageFileThumbUri, imageFileSourceUri);
 
     }


### PR DESCRIPTION
修改的部分，針對
https://github.com/wildfirechat/android-chat/issues/219#issue-528452683
無法傳送中文檔名的圖片。
Uri.fromFile()遇到中文、日文檔名會轉 ASCII URI，這個 ASCII 的 path 將導致後面 ChatManager.sendMessage()在 new File()時找不到 File 而 return，如下圖：
![image](https://user-images.githubusercontent.com/3890826/69598178-7e894500-1043-11ea-8cc1-74b07ab5356e.png)

我修改 MessageViewModel.java 裡取 URI 的方式：
原本的：
`Uri imageFileSourceUri = Uri.fromFile(imageFileSource);`
改成：
`Uri imageFileSourceUri = Uri.parse(Uri.decode(imageFileSource.getAbsolutePath()));`