### PR TITLE
将聊天message_container的布局文件中部分动态渲染的TextView的默认文案改为仅在预览模式下显示

### DIFF
--- a/chat/kit/src/main/res/layout/conversation_item_message_container_receive.xml
+++ b/chat/kit/src/main/res/layout/conversation_item_message_container_receive.xml
@@ -19,7 +19,7 @@
         android:paddingTop="2dp"
         android:paddingRight="5dp"
         android:paddingBottom="2dp"
-        android:text="下午 5点"
+        tools:text="下午 5点"
         android:textColor="@color/gray11"
         android:textSize="14sp" />
 
@@ -50,7 +50,7 @@
                 android:ellipsize="end"
                 android:maxLength="20"
                 android:singleLine="true"
-                android:text="imndx"
+                tools:text="imndx"
                 android:textColor="#666666"
                 android:textSize="12sp"
                 android:visibility="gone"

--- a/chat/kit/src/main/res/layout/conversation_item_message_container_send.xml
+++ b/chat/kit/src/main/res/layout/conversation_item_message_container_send.xml
@@ -19,7 +19,7 @@
         android:paddingTop="2dp"
         android:paddingRight="5dp"
         android:paddingBottom="2dp"
-        android:text="下午 5点"
+        tools:text="下午 5点"
         android:textColor="@color/gray11"
         android:textSize="14sp" />
 
@@ -55,7 +55,7 @@
             <include layout="@layout/include_error" />
         </LinearLayout>
 
-        <ProgressBar xmlns:tools="http://schemas.android.com/tools"
+        <ProgressBar
             android:id="@+id/progressBar"
             style="?android:attr/progressBarStyleSmall"
             android:layout_width="20dp"
@@ -89,7 +89,7 @@
                 android:ellipsize="end"
                 android:maxLength="20"
                 android:singleLine="true"
-                android:text="imndx"
+                tools:text="imndx"
                 android:textColor="#666666"
                 android:textSize="12sp"
                 android:visibility="gone"

--- a/chat/kit/src/main/res/layout/conversation_item_notification_containr.xml
+++ b/chat/kit/src/main/res/layout/conversation_item_notification_containr.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <cn.wildfire.chat.kit.conversation.message.MessageItemView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/contentFrameLayout"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
@@ -20,7 +21,7 @@
         android:paddingTop="2dp"
         android:paddingRight="5dp"
         android:paddingBottom="2dp"
-        android:text="下午 5点"
+        tools:text="下午 5点"
         android:textColor="#fff"
         android:textSize="12sp" />
 

--- a/chat/kit/src/main/res/layout/conversation_item_unknown_receive.xml
+++ b/chat/kit/src/main/res/layout/conversation_item_unknown_receive.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <TextView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/contentTextView"
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
@@ -12,7 +13,7 @@
     android:paddingLeft="16dp"
     android:paddingRight="16dp"
     android:paddingTop="12dp"
-    android:text="嗯嗯嗯嗯嗯嗯嗯"
+    tools:text="嗯嗯嗯嗯嗯嗯嗯"
     android:textColor="#444444"
     android:textColorLink="#666666"
     android:textSize="16sp" />

--- a/chat/kit/src/main/res/layout/conversation_item_unknown_send.xml
+++ b/chat/kit/src/main/res/layout/conversation_item_unknown_send.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <TextView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/contentTextView"
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
@@ -13,7 +14,7 @@
     android:paddingLeft="16dp"
     android:paddingRight="16dp"
     android:paddingTop="12dp"
-    android:text="嗯嗯嗯嗯嗯嗯"
+    tools:text="嗯嗯嗯嗯嗯嗯"
     android:textColor="#ffff"
     android:textColorLink="#3655bf"
     android:textSize="16sp" />


### PR DESCRIPTION
例如`conversation_item_unknown_receive.xml`16行的`android:text="嗯嗯嗯嗯嗯嗯嗯"`

"嗯嗯"这样的文字仅仅是为了在layout editor中调试UI，实际环境中应该为空

真实环境下都是通过接口获取聊天消息的文本去显示的TextView

按照[安卓文档](https://developer.android.com/studio/write/tool-attributes#design-time_view_attributes)上的建议应当设为**tools:text**属性：

```
if the android:text attribute value is set at runtime
or you want to see the layout with a value different than the default,
you can add tools:text to specify some text for the layout preview only.
```

应该将聊天消息中的文本、时间等TextView的android:text换成tools:text