### PR TITLE
优化语音和键盘输入切换

### DIFF
--- a/uikit/src/main/res/layout/conversation_input_panel.xml
+++ b/uikit/src/main/res/layout/conversation_input_panel.xml
@@ -33,7 +33,7 @@
                 android:scaleType="centerInside"
                 android:src="@mipmap/ic_cheat_voice" />
 
-            <RelativeLayout
+            <FrameLayout
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"
                 android:layout_gravity="center_vertical"
@@ -50,7 +50,6 @@
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
                         android:layout_centerInParent="true"
-                        android:layout_marginTop="5dp"
                         android:background="@drawable/shape_session_text_input"
                         android:maxLines="5"
                         android:minHeight="42dp"
@@ -101,7 +100,7 @@
                     android:visibility="gone"
                     tools:visibility="gone" />
 
-            </RelativeLayout>
+            </FrameLayout>
 
             <ImageView
                 android:id="@+id/emotionImageView"


### PR DESCRIPTION
在低端手机中，切换语音发送和文本发送时出现的问题

复现：输入框中随便输入一些值，然后点发送语音按钮，然后切换回文本输入，此时部分手机会闪烁（conversation_input_panel.xml）